### PR TITLE
Update bigtable-client-core to 0.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <netty.version>4.1.1.Final</netty.version>
+    <netty.version>4.1.6.Final</netty.version>
   </properties>
 
   <parent>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-client-core</artifactId>
-      <version>0.9.4</version>
+      <version>0.9.5</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
At the request of Google engineers via support ticket: https://enterprise.google.com/supportcenter/managecases#Case/0016000000sFY8w/U-11912069