### PR TITLE
Release 0.1.0-beta9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>simple-bigtable</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.0-beta9</version>
   <packaging>jar</packaging>
   <name>simple-bigtable</name>
   <description>A wrapper around the Bigtable RPC client</description>


### PR DESCRIPTION
With bigtable-client-core 0.9.5.