### PR TITLE
Add ByteString key methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
 
   <developers>
     <developer>
-      <id>rgruener</id>
-      <name>Robert Gruener</name>
-      <email>robertg@spotify.com</email>
+      <id>keithmcneill</id>
+      <name>Keith McNeill</name>
+      <email>kdm@spotify.com</email>
       <organization>Spotify AB</organization>
       <organizationUrl>http://www.spotify.com</organizationUrl>
       <roles>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>6</version>
   </parent>
 
-  <artifactId>inferno-simple-bigtable</artifactId>
+  <artifactId>simple-bigtable</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>simple-bigtable</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <version>6</version>
   </parent>
 
-  <artifactId>simple-bigtable</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <artifactId>inferno-simple-bigtable</artifactId>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>simple-bigtable</name>
   <description>A wrapper around the Bigtable RPC client</description>

--- a/src/main/java/com/spotify/bigtable/read/ReadRows.java
+++ b/src/main/java/com/spotify/bigtable/read/ReadRows.java
@@ -63,7 +63,20 @@ public class ReadRows {
   public interface RowsRead extends RowRead<
       FamilyWithinRowsRead, FamiliesWithinRowsRead, ColumnWithinRowsRead, List<Row>> {
 
+    /**
+     * Add a collection of keys to the read.
+     * @param rowKeys collection of keys
+     * @return a RowsRead
+     * @deprecated use ByteString version as keys are binary
+     */
     RowsRead addKeys(final Collection<String> rowKeys);
+
+    /**
+     * Add a collection of keys to the read.
+     * @param rowKeys collection of keys
+     * @return a RowsRead
+     */
+    RowsRead addBinaryKeys(final Collection<ByteString> rowKeys);
 
     RowsRead limit(final long limit);
 
@@ -86,7 +99,13 @@ public class ReadRows {
     public RowsReadImpl addKeys(Collection<String> rowKeys) {
       final Set<ByteString> iterator =
           rowKeys.stream().map(ByteString::copyFromUtf8).collect(Collectors.toSet());
-      readRequest.setRows(readRequest.getRowsBuilder().addAllRowKeys(iterator));
+      addBinaryKeys(iterator);
+      return this;
+    }
+
+    @Override
+    public RowsReadImpl addBinaryKeys(Collection<ByteString> rowKeys) {
+      readRequest.setRows(readRequest.getRowsBuilder().addAllRowKeys(rowKeys));
       return this;
     }
 

--- a/src/main/java/com/spotify/bigtable/read/ReadRows.java
+++ b/src/main/java/com/spotify/bigtable/read/ReadRows.java
@@ -64,19 +64,20 @@ public class ReadRows {
       FamilyWithinRowsRead, FamiliesWithinRowsRead, ColumnWithinRowsRead, List<Row>> {
 
     /**
-     * Add a collection of keys to the read.
-     * @param rowKeys collection of keys
+     * Add a collection of String keys to the read.  BigTable stores keys as an byte[]. This method
+     * will incur a conversion of each String key to ByteString key.  Use
+     * {@link #addKeysBinary(Collection)} instead.
+     * @param rowKeys collection of String keys
      * @return a RowsRead
-     * @deprecated use ByteString version as keys are binary
      */
     RowsRead addKeys(final Collection<String> rowKeys);
 
     /**
-     * Add a collection of keys to the read.
-     * @param rowKeys collection of keys
+     * Add a collection of Binary keys to the read.
+     * @param rowKeys collection of ByteString keys
      * @return a RowsRead
      */
-    RowsRead addBinaryKeys(final Collection<ByteString> rowKeys);
+    RowsRead addKeysBinary(final Collection<ByteString> rowKeys);
 
     RowsRead limit(final long limit);
 
@@ -99,12 +100,12 @@ public class ReadRows {
     public RowsReadImpl addKeys(Collection<String> rowKeys) {
       final Set<ByteString> iterator =
           rowKeys.stream().map(ByteString::copyFromUtf8).collect(Collectors.toSet());
-      addBinaryKeys(iterator);
+      addKeysBinary(iterator);
       return this;
     }
 
     @Override
-    public RowsReadImpl addBinaryKeys(Collection<ByteString> rowKeys) {
+    public RowsReadImpl addKeysBinary(Collection<ByteString> rowKeys) {
       readRequest.setRows(readRequest.getRowsBuilder().addAllRowKeys(rowKeys));
       return this;
     }

--- a/src/main/java/com/spotify/bigtable/read/TableRead.java
+++ b/src/main/java/com/spotify/bigtable/read/TableRead.java
@@ -57,18 +57,20 @@ import java.util.function.Function;
 public interface TableRead {
 
   /**
-   * Read from a single row with given key.
-   *
-   * @param row row key
+   * Read from a single row with String given key. BigTable stores keys as an byte[]. This method
+   * will incur a conversion of each String key to ByteString key.  Use
+   * {@link #rowWithBinaryKey(ByteString)}
+   * @param row a String row key
    * @return Row Read implementation
-   * @deprecated use ByteString version since keys are binary
    */
   RowSingleRead row(final String row);
 
   RowsRead rows();
 
   /**
-   * Read rows from a colleciton of keys.
+   * Read rows from a collection of String keys.  BigTable stores keys as an byte[]. This method
+   * will incur a conversion of each String key to ByteString key.  Use
+   * {@link #rowsWithBinaryKeys(Collection)}
    * @param rowKeys Collection of String keys
    * @return MutliReadRow
    * @deprecated use ByteString version since keys are binary
@@ -77,17 +79,17 @@ public interface TableRead {
 
   /**
    * Read from a single row with given binary key.
-   * @param row row key
+   * @param row a ByteString row key
    * @return Row Read implementation
    */
-  RowSingleRead rowFromBinaryKey(final ByteString row);
+  RowSingleRead rowWithBinaryKey(final ByteString row);
 
   /**
    * Read rows from a colleciton of keys.
-   * @param rowKeys Collection of String keys
+   * @param rowKeys Collection of ByteString keys
    * @return MutliReadRow
    */
-  RowMultiRead rowsFromBinaryKeys(final Collection<ByteString> rowKeys);
+  RowMultiRead rowsWithBinaryKeys(final Collection<ByteString> rowKeys);
 
   class TableReadImpl extends BigtableTable implements TableRead, BigtableRead.Internal<List<Row>> {
 
@@ -113,14 +115,14 @@ public interface TableRead {
     }
 
     @Override
-    public RowSingleRead.ReadImpl rowFromBinaryKey(final ByteString row) {
-      final RowsReadImpl rowsRead = rows().addBinaryKeys(Collections.singleton(row)).limit(1);
+    public RowSingleRead.ReadImpl rowWithBinaryKey(final ByteString row) {
+      final RowsReadImpl rowsRead = rows().addKeysBinary(Collections.singleton(row)).limit(1);
       return new RowSingleRead.ReadImpl(rowsRead);
     }
 
     @Override
-    public RowMultiRead.ReadImpl rowsFromBinaryKeys(final Collection<ByteString> rowKeys) {
-      final RowsReadImpl rowsRead = rows().addBinaryKeys(rowKeys).limit(rowKeys.size());
+    public RowMultiRead.ReadImpl rowsWithBinaryKeys(final Collection<ByteString> rowKeys) {
+      final RowsReadImpl rowsRead = rows().addKeysBinary(rowKeys).limit(rowKeys.size());
       return new RowMultiRead.ReadImpl(rowsRead);
     }
 

--- a/src/main/java/com/spotify/bigtable/read/TableRead.java
+++ b/src/main/java/com/spotify/bigtable/read/TableRead.java
@@ -42,6 +42,7 @@ package com.spotify.bigtable.read;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.Row;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
+import com.google.protobuf.ByteString;
 import com.spotify.bigtable.Bigtable;
 import com.spotify.bigtable.BigtableTable;
 import com.spotify.bigtable.read.ReadRow.RowMultiRead;
@@ -60,13 +61,33 @@ public interface TableRead {
    *
    * @param row row key
    * @return Row Read implementation
+   * @deprecated use ByteString version since keys are binary
    */
   RowSingleRead row(final String row);
 
-  RowMultiRead rows(final Collection<String> rowKeys);
-
   RowsRead rows();
 
+  /**
+   * Read rows from a colleciton of keys.
+   * @param rowKeys Collection of String keys
+   * @return MutliReadRow
+   * @deprecated use ByteString version since keys are binary
+   */
+  RowMultiRead rows(final Collection<String> rowKeys);
+
+  /**
+   * Read from a single row with given binary key.
+   * @param row row key
+   * @return Row Read implementation
+   */
+  RowSingleRead rowFromBinaryKey(final ByteString row);
+
+  /**
+   * Read rows from a colleciton of keys.
+   * @param rowKeys Collection of String keys
+   * @return MutliReadRow
+   */
+  RowMultiRead rowsFromBinaryKeys(final Collection<ByteString> rowKeys);
 
   class TableReadImpl extends BigtableTable implements TableRead, BigtableRead.Internal<List<Row>> {
 
@@ -74,6 +95,7 @@ public interface TableRead {
       super(bigtable, table);
     }
 
+    @Override
     public RowSingleRead.ReadImpl row(final String row) {
       final RowsReadImpl rowsRead = rows().addKeys(Collections.singleton(row)).limit(1);
       return new RowSingleRead.ReadImpl(rowsRead);
@@ -87,6 +109,18 @@ public interface TableRead {
     @Override
     public RowMultiRead.ReadImpl rows(final Collection<String> rowKeys) {
       final RowsReadImpl rowsRead = rows().addKeys(rowKeys).limit(rowKeys.size());
+      return new RowMultiRead.ReadImpl(rowsRead);
+    }
+
+    @Override
+    public RowSingleRead.ReadImpl rowFromBinaryKey(final ByteString row) {
+      final RowsReadImpl rowsRead = rows().addBinaryKeys(Collections.singleton(row)).limit(1);
+      return new RowSingleRead.ReadImpl(rowsRead);
+    }
+
+    @Override
+    public RowMultiRead.ReadImpl rowsFromBinaryKeys(final Collection<ByteString> rowKeys) {
+      final RowsReadImpl rowsRead = rows().addBinaryKeys(rowKeys).limit(rowKeys.size());
       return new RowMultiRead.ReadImpl(rowsRead);
     }
 

--- a/src/test/java/com/spotify/bigtable/read/RowReadImplTest.java
+++ b/src/test/java/com/spotify/bigtable/read/RowReadImplTest.java
@@ -51,6 +51,7 @@ import com.google.bigtable.v2.Row;
 import com.google.bigtable.v2.RowFilter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
+import com.google.protobuf.ByteString;
 import com.spotify.bigtable.BigtableMock;
 import java.util.Collections;
 import java.util.List;
@@ -61,16 +62,28 @@ public class RowReadImplTest {
 
   BigtableMock bigtableMock = BigtableMock.getMock();
   ReadRow.RowSingleRead.ReadImpl rowRead;
+  ReadRow.RowSingleRead.ReadImpl binaryRowRead;
+  private final ByteString BINARY_KEY = ByteString.copyFrom( new byte[]
+      {'D', 'E', 'A', 'D', 'B', 'E', 'E', 'F'});
 
   @Before
   public void setUp() throws Exception {
     final TableRead.TableReadImpl tableRead = new TableRead.TableReadImpl(bigtableMock, "table");
     rowRead = tableRead.row("row");
+    binaryRowRead = tableRead.rowFromBinaryKey(BINARY_KEY);
   }
 
   private void verifyReadRequest(ReadRowsRequest.Builder readRequest) throws Exception {
     assertEquals(bigtableMock.getFullTableName("table"), readRequest.getTableName());
     assertEquals("row", readRequest.getRows().getRowKeys(0).toStringUtf8());
+    assertEquals(1, readRequest.getRows().getRowKeysCount());
+    assertEquals(0, readRequest.getRows().getRowRangesCount());
+    assertEquals(1, readRequest.getRowsLimit());
+  }
+
+  private void verifyBinaryReadRequest(ReadRowsRequest.Builder readRequest) throws Exception {
+    assertEquals(bigtableMock.getFullTableName("table"), readRequest.getTableName());
+    assertEquals(BINARY_KEY, readRequest.getRows().getRowKeys(0));
     assertEquals(1, readRequest.getRows().getRowKeysCount());
     assertEquals(0, readRequest.getRows().getRowRangesCount());
     assertEquals(1, readRequest.getRowsLimit());
@@ -85,10 +98,21 @@ public class RowReadImplTest {
   public void testExecuteAsync() throws Exception {
     verifyReadRequest(rowRead.readRequest());
     when(bigtableMock.getMockedDataClient().readRowsAsync(any()))
-            .thenReturn(Futures.immediateFuture(Collections.emptyList()));
+        .thenReturn(Futures.immediateFuture(Collections.emptyList()));
 
     rowRead.executeAsync();
     verify(bigtableMock.getMockedDataClient()).readRowsAsync(rowRead.readRequest().build());
+    verifyNoMoreInteractions(bigtableMock.getMockedDataClient());
+  }
+
+  @Test
+  public void testBinaryExecuteAsync() throws Exception {
+    verifyBinaryReadRequest(binaryRowRead.readRequest());
+    when(bigtableMock.getMockedDataClient().readRowsAsync(any()))
+        .thenReturn(Futures.immediateFuture(Collections.emptyList()));
+
+    binaryRowRead.executeAsync();
+    verify(bigtableMock.getMockedDataClient()).readRowsAsync(binaryRowRead.readRequest().build());
     verifyNoMoreInteractions(bigtableMock.getMockedDataClient());
   }
 
@@ -98,6 +122,14 @@ public class RowReadImplTest {
 
     final Row row = Row.getDefaultInstance();
     assertEquals(row, rowRead.toDataType().apply(ImmutableList.of(row)).get());
+  }
+
+  @Test
+  public void testBinaryToDataType() throws Exception {
+    assertFalse(binaryRowRead.toDataType().apply(ImmutableList.of()).isPresent());
+
+    final Row row = Row.getDefaultInstance();
+    assertEquals(row, binaryRowRead.toDataType().apply(ImmutableList.of(row)).get());
   }
 
   @Test
@@ -114,12 +146,38 @@ public class RowReadImplTest {
   }
 
   @Test
+  public void testBinaryFamily() throws Exception {
+    final ReadFamily.FamilyWithinRowRead.ReadImpl family =
+        (ReadFamily.FamilyWithinRowRead.ReadImpl) binaryRowRead.family("family");
+
+    final ReadRowsRequest.Builder readRequest = family.readRequest();
+    verifyBinaryReadRequest(readRequest);
+    assertEquals(2, readRequest.getFilter().getChain().getFiltersCount());
+    assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().getChain().getFilters(0));
+    assertEquals(AbstractBigtableRead.toExactMatchRegex("family"), readRequest.getFilter().getChain().getFilters(1).getFamilyNameRegexFilter());
+    assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().toBuilder().clearChain().build());
+  }
+
+  @Test
   public void testFamilyRegex() throws Exception {
     final ReadFamilies.FamiliesWithinRowRead.ReadImpl families =
         (ReadFamilies.FamiliesWithinRowRead.ReadImpl) rowRead.familyRegex("family-regex");
 
     final ReadRowsRequest.Builder readRequest = families.readRequest();
     verifyReadRequest(readRequest);
+    assertEquals(2, readRequest.getFilter().getChain().getFiltersCount());
+    assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().getChain().getFilters(0));
+    assertEquals("family-regex", readRequest.getFilter().getChain().getFilters(1).getFamilyNameRegexFilter());
+    assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().toBuilder().clearChain().build());
+  }
+
+  @Test
+  public void testBinaryFamilyRegex() throws Exception {
+    final ReadFamilies.FamiliesWithinRowRead.ReadImpl families =
+        (ReadFamilies.FamiliesWithinRowRead.ReadImpl) binaryRowRead.familyRegex("family-regex");
+
+    final ReadRowsRequest.Builder readRequest = families.readRequest();
+    verifyBinaryReadRequest(readRequest);
     assertEquals(2, readRequest.getFilter().getChain().getFiltersCount());
     assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().getChain().getFilters(0));
     assertEquals("family-regex", readRequest.getFilter().getChain().getFilters(1).getFamilyNameRegexFilter());
@@ -141,12 +199,41 @@ public class RowReadImplTest {
   }
 
   @Test
+  public void testBinaryFamilies() throws Exception {
+    final List<String> familyNames = ImmutableList.of("family1", "family2");
+    final ReadFamilies.FamiliesWithinRowRead.ReadImpl families =
+        (ReadFamilies.FamiliesWithinRowRead.ReadImpl) binaryRowRead.families(familyNames);
+
+    final ReadRowsRequest.Builder readRequest = families.readRequest();
+    verifyBinaryReadRequest(readRequest);
+    assertEquals(2, readRequest.getFilter().getChain().getFiltersCount());
+    assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().getChain().getFilters(0));
+    assertEquals(AbstractBigtableRead.toExactMatchAnyRegex(familyNames), readRequest.getFilter().getChain().getFilters(1).getFamilyNameRegexFilter());
+    assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().toBuilder().clearChain().build());
+  }
+
+  @Test
   public void testColumn() throws Exception {
     final ReadColumn.ColumnWithinFamilyRead.ReadImpl column =
         (ReadColumn.ColumnWithinFamilyRead.ReadImpl) rowRead.column("family:qualifier");
 
     final ReadRowsRequest.Builder readRequest = column.readRequest();
     verifyReadRequest(readRequest);
+    assertEquals(3, readRequest.getFilter().getChain().getFiltersCount());
+    assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().getChain().getFilters(0));
+    assertEquals(AbstractBigtableRead.toExactMatchRegex("family"), readRequest.getFilter().getChain().getFilters(1).getFamilyNameRegexFilter());
+    assertEquals(AbstractBigtableRead.toExactMatchRegex("qualifier"), readRequest.getFilter().getChain().getFilters(2).getColumnQualifierRegexFilter().toStringUtf8());
+    assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().toBuilder().clearChain().build()
+    );
+  }
+
+  @Test
+  public void testBinaryColumn() throws Exception {
+    final ReadColumn.ColumnWithinFamilyRead.ReadImpl column =
+        (ReadColumn.ColumnWithinFamilyRead.ReadImpl) binaryRowRead.column("family:qualifier");
+
+    final ReadRowsRequest.Builder readRequest = column.readRequest();
+    verifyBinaryReadRequest(readRequest);
     assertEquals(3, readRequest.getFilter().getChain().getFiltersCount());
     assertEquals(RowFilter.getDefaultInstance(), readRequest.getFilter().getChain().getFilters(0));
     assertEquals(AbstractBigtableRead.toExactMatchRegex("family"), readRequest.getFilter().getChain().getFilters(1).getFamilyNameRegexFilter());

--- a/src/test/java/com/spotify/bigtable/read/RowReadImplTest.java
+++ b/src/test/java/com/spotify/bigtable/read/RowReadImplTest.java
@@ -70,7 +70,7 @@ public class RowReadImplTest {
   public void setUp() throws Exception {
     final TableRead.TableReadImpl tableRead = new TableRead.TableReadImpl(bigtableMock, "table");
     rowRead = tableRead.row("row");
-    binaryRowRead = tableRead.rowFromBinaryKey(BINARY_KEY);
+    binaryRowRead = tableRead.rowWithBinaryKey(BINARY_KEY);
   }
 
   private void verifyReadRequest(ReadRowsRequest.Builder readRequest) throws Exception {

--- a/src/test/java/com/spotify/bigtable/read/TableReadImplTest.java
+++ b/src/test/java/com/spotify/bigtable/read/TableReadImplTest.java
@@ -107,7 +107,7 @@ public class TableReadImplTest {
   public void testBinaryKeysRowsCollection() throws Exception {
     final ImmutableSet<ByteString> rowKeys = ImmutableSet.of(ByteString.copyFromUtf8("row1"),
         ByteString.copyFromUtf8("row2"));
-    final ReadRow.RowMultiRead.ReadImpl rows = tableRead.rowsFromBinaryKeys(rowKeys);
+    final ReadRow.RowMultiRead.ReadImpl rows = tableRead.rowsWithBinaryKeys(rowKeys);
     final ReadRowsRequest.Builder readRequest = rows.readRequest();
     verifyReadRequest(readRequest);
     assertEquals(rowKeys, Sets.newHashSet(readRequest.getRows().getRowKeysList()));

--- a/src/test/java/com/spotify/bigtable/read/TableReadImplTest.java
+++ b/src/test/java/com/spotify/bigtable/read/TableReadImplTest.java
@@ -104,6 +104,20 @@ public class TableReadImplTest {
   }
 
   @Test
+  public void testBinaryKeysRowsCollection() throws Exception {
+    final ImmutableSet<ByteString> rowKeys = ImmutableSet.of(ByteString.copyFromUtf8("row1"),
+        ByteString.copyFromUtf8("row2"));
+    final ReadRow.RowMultiRead.ReadImpl rows = tableRead.rowsFromBinaryKeys(rowKeys);
+    final ReadRowsRequest.Builder readRequest = rows.readRequest();
+    verifyReadRequest(readRequest);
+    assertEquals(rowKeys, Sets.newHashSet(readRequest.getRows().getRowKeysList()));
+    assertEquals(2, readRequest.getRows().getRowKeysCount());
+    assertEquals(0, readRequest.getRows().getRowRangesCount());
+    assertEquals(2, readRequest.getRowsLimit());
+    assertEquals(bigtableMock.getMockedDataClient(), rows.getClient());
+  }
+
+  @Test
   public void testGetClient() throws Exception {
     assertEquals(bigtableMock.getMockedDataClient(), tableRead.getClient());
   }


### PR DESCRIPTION
Bigtable keys are binary.  If binary keys are used you need ByteString methods to do by key lookup.

Unfortunately because of erasure I couldn't just overload the addKey(), and rows() methods.  I'm up for better method names.

I added @deprecated tags to the String methods.  Really should just use the ByteString methods.  I see no reason to hide the fact that keys are Binary from users, and the String addKey methods just end up creating ByteStrings anyway.