### PR TITLE
update to version 1.6.0 of bigtable client core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>simple-bigtable</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <packaging>jar</packaging>
   <name>simple-bigtable</name>
   <description>A wrapper around the Bigtable RPC client</description>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-client-core</artifactId>
-      <version>1.3.0</version>
+      <version>1.6.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -78,16 +78,16 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Bigtable Needs Guava 19  -->
+    <!-- Bigtable Needs Guava 20  -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>20.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.23.0</version>
+      <version>1.24.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
-      <version>1.10.0</version>
+      <version>1.13.1</version>
     </dependency>
     <!-- BigTable needs this version of Netty included to connect include linux and osx base 64 versions-->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.spotify.metrics</groupId>
       <artifactId>semantic-metrics-core</artifactId>
-      <version>0.6.0</version>
+      <version>0.11.5</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
@keithmcneill Updated other dependent dependencies.
Also updated semantic-metrics-core library to the most latest version that doesn't break other dependencies.