### PR TITLE
upgrade bigtable client to remove old guava dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>simple-bigtable</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <packaging>jar</packaging>
   <name>simple-bigtable</name>
   <description>A wrapper around the Bigtable RPC client</description>
@@ -52,14 +52,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.spotify</groupId>
-      <artifactId>futures-extra</artifactId>
-      <version>2.6.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-client-core</artifactId>
-      <version>1.6.0</version>
+      <version>1.7.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -78,16 +73,10 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Bigtable Needs Guava 20  -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>20.0</version>
-    </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.24.1</version>
+      <version>1.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>
@@ -97,7 +86,12 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
-      <version>1.13.1</version>
+      <version>1.16.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>animal-sniffer-annotations</artifactId>
+      <version>1.17</version>
     </dependency>
     <!-- BigTable needs this version of Netty included to connect include linux and osx base 64 versions-->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,10 @@
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.7.9</version>

--- a/src/main/java/com/spotify/bigtable/read/AbstractBigtableRead.java
+++ b/src/main/java/com/spotify/bigtable/read/AbstractBigtableRead.java
@@ -43,8 +43,10 @@ import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.Row;
 import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.spotify.futures.FuturesExtra;
+import com.google.common.util.concurrent.MoreExecutors;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -72,7 +74,8 @@ abstract class AbstractBigtableRead<P, T> implements BigtableRead<T>, BigtableRe
   @Override
   public ListenableFuture<T> executeAsync() {
     final ListenableFuture<List<Row>> future = getClient().readRowsAsync(readRequest().build());
-    return FuturesExtra.syncTransform(future, rows -> toDataType().apply(rows));
+    return Futures.transform(future, rows -> toDataType().apply(rows),
+            MoreExecutors.directExecutor());
   }
 
   @Override

--- a/src/test/java/com/spotify/bigtable/BigtableMock.java
+++ b/src/test/java/com/spotify/bigtable/BigtableMock.java
@@ -39,7 +39,6 @@
 
 package com.spotify.bigtable;
 
-import com.google.api.client.repackaged.com.google.common.base.Throwables;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
@@ -78,7 +77,7 @@ public class BigtableMock extends Bigtable {
       Mockito.when(session.getOptions()).thenReturn(options);
       Mockito.when(options.getInstanceName()).thenReturn(new BigtableInstanceName(PROJECT_ID, INSTANCE_ID));
     } catch (IOException e) {
-      Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     return new BigtableMock(session, PROJECT_ID, INSTANCE_ID);
@@ -94,7 +93,7 @@ public class BigtableMock extends Bigtable {
       Mockito.when(session.getDataClient()).thenReturn(dataClient);
       Mockito.when(session.getTableAdminClient()).thenReturn(tableAdminClient);
     } catch (IOException e) {
-      Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     return new BigtableMock(session, project, instance);


### PR DESCRIPTION
updated bigtable-client-core to remove the dependency on guava 20 - which had a few missing api causing
exceptions like below:

`java.lang.NoSuchMethodError: com.google.common.util.concurrent.Futures.transform(Lcom/google/common/util/concurrent/ListenableFuture;Lcom/google/common/base/Function;)Lcom/google/common/util/concurrent/ListenableFuture;` 